### PR TITLE
Fix API requests rejected due to missing app User-Agent

### DIFF
--- a/custom_components/rinnai/const.py
+++ b/custom_components/rinnai/const.py
@@ -36,6 +36,14 @@ ENTITY_CATEGORY_CONFIG: Final = "config"
 HOST: Final = "https://iot.rinnai.com.cn/app"
 BASE_URL: Final = HOST
 
+# The API gateway rejects aiohttp's default User-Agent with a HTML response.
+# Keep these values aligned with the current Rinnai Smart Home app.
+APP_VERSION: Final = "3.10.0"
+APP_USER_AGENT: Final = (
+    f"lin nei zhi jia/{APP_VERSION} (iPhone; iOS 27.0; Scale/3.00)"
+)
+API_HEADERS: Final = {"User-Agent": APP_USER_AGENT}
+
 # Rinnai Smart Home app built-in accessKey
 AK: Final = "A39C66706B83CCF0C0EE3CB23A39454D"
 REFESH_TIME: Final = 86400  # 24 hours
@@ -287,6 +295,5 @@ MQTT_DEFINITIONS: Final = {
         "heartbeat_pattern": "JA4",
     }
 }
-
 
 

--- a/custom_components/rinnai/core/client.py
+++ b/custom_components/rinnai/core/client.py
@@ -14,7 +14,15 @@ import aiohttp
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from ..const import AK, REFESH_TIME, BASE_URL, API_DEFINITIONS, MQTT_DEFINITIONS
+from ..const import (
+    AK,
+    API_DEFINITIONS,
+    API_HEADERS,
+    APP_VERSION,
+    BASE_URL,
+    MQTT_DEFINITIONS,
+    REFESH_TIME,
+)
 from .config_manager import config_manager
 from .mqtt_client import RinnaiMQTTClient
 
@@ -64,6 +72,13 @@ class RinnaiClient:
 
         # Track initialization status
         self._initialized = False
+
+    def _http_headers(self, *, authenticated: bool = False) -> dict[str, str]:
+        """Build headers accepted by the Rinnai API gateway."""
+        headers = dict(API_HEADERS)
+        if authenticated:
+            headers["Authorization"] = f"Basic {self._token}"
+        return headers
 
     def register_callback(
         self, device_id: str, callback_func: Callable[[dict[str, Any]], None]
@@ -120,7 +135,7 @@ class RinnaiClient:
                         "password": self.password_hash,
                         "accessKey": AK,
                         "appType": "2",
-                        "appVersion": "3.9.0",
+                        "appVersion": APP_VERSION,
                         "identityLevel": "0",
                     }
 
@@ -128,7 +143,7 @@ class RinnaiClient:
                     response = await self._session.get(
                         url,
                         params=login_data,
-                        headers={"Content-Type": "application/json"},
+                        headers=self._http_headers(),
                     )
 
                     resp_json = await response.json()
@@ -142,6 +157,19 @@ class RinnaiClient:
                     self._token = resp_json.get("data", {}).get("token")
                     self._last_login_time = time.time()
                     return True
+            except aiohttp.ContentTypeError as err:
+                content_type = (
+                    err.headers.get("Content-Type", "unknown")
+                    if err.headers
+                    else "unknown"
+                )
+                _LOGGER.error(
+                    "Rinnai API returned a non-JSON login response "
+                    "(status=%s, content_type=%s)",
+                    err.status,
+                    content_type,
+                )
+                return False
             except (TimeoutError, aiohttp.ClientError) as err:
                 _LOGGER.error("Error connecting to Rinnai API: %s", err)
                 return False
@@ -153,7 +181,7 @@ class RinnaiClient:
 
         try:
             async with asyncio.timeout(self.connect_timeout):
-                headers = {"Authorization": f"Basic {self._token}"}
+                headers = self._http_headers(authenticated=True)
                 url = f"{BASE_URL}{API_DEFINITIONS['device_list']['url']}"
                 response = await self._session.get(url, headers=headers)
                 resp_json = await response.json()
@@ -202,7 +230,7 @@ class RinnaiClient:
 
         try:
             async with asyncio.timeout(self.connect_timeout):
-                headers = {"Authorization": f"Basic {self._token}"}
+                headers = self._http_headers(authenticated=True)
                 url = f"{BASE_URL}{API_DEFINITIONS['device_state']['url']}"
                 response = await self._session.get(
                     url,
@@ -302,7 +330,7 @@ class RinnaiClient:
 
         try:
             async with asyncio.timeout(self.connect_timeout):
-                headers = {"Authorization": f"Basic {self._token}"}
+                headers = self._http_headers(authenticated=True)
                 
                 if method == "GET":
                     response = await self._session.get(url, params=final_params, headers=headers)

--- a/tests/test_client_http.py
+++ b/tests/test_client_http.py
@@ -1,0 +1,101 @@
+"""Tests for Rinnai HTTP request metadata."""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def client_module(monkeypatch):
+    """Import the client with lightweight Home Assistant and MQTT stubs."""
+    integration_dir = Path(__file__).parents[1] / "custom_components" / "rinnai"
+    custom_components = ModuleType("custom_components")
+    custom_components.__path__ = [str(integration_dir.parent)]
+    rinnai = ModuleType("custom_components.rinnai")
+    rinnai.__path__ = [str(integration_dir)]
+    core = ModuleType("custom_components.rinnai.core")
+    core.__path__ = [str(integration_dir / "core")]
+    monkeypatch.setitem(sys.modules, "custom_components", custom_components)
+    monkeypatch.setitem(sys.modules, "custom_components.rinnai", rinnai)
+    monkeypatch.setitem(sys.modules, "custom_components.rinnai.core", core)
+
+    aiohttp = ModuleType("aiohttp")
+
+    class ClientError(Exception):
+        """Stub aiohttp client error."""
+
+    class ContentTypeError(ClientError):
+        """Stub aiohttp content type error."""
+
+    aiohttp.ClientError = ClientError
+    aiohttp.ContentTypeError = ContentTypeError
+    monkeypatch.setitem(sys.modules, "aiohttp", aiohttp)
+
+    homeassistant = ModuleType("homeassistant")
+    homeassistant.__path__ = []
+    homeassistant_core = ModuleType("homeassistant.core")
+    homeassistant_core.HomeAssistant = object
+    homeassistant_core.callback = lambda func: func
+    homeassistant_helpers = ModuleType("homeassistant.helpers")
+    homeassistant_helpers.__path__ = []
+    homeassistant_aiohttp = ModuleType("homeassistant.helpers.aiohttp_client")
+    homeassistant_aiohttp.async_get_clientsession = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "homeassistant", homeassistant)
+    monkeypatch.setitem(sys.modules, "homeassistant.core", homeassistant_core)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers", homeassistant_helpers)
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.helpers.aiohttp_client", homeassistant_aiohttp
+    )
+
+    mqtt_client = ModuleType("custom_components.rinnai.core.mqtt_client")
+    mqtt_client.RinnaiMQTTClient = MagicMock()
+    monkeypatch.setitem(
+        sys.modules, "custom_components.rinnai.core.mqtt_client", mqtt_client
+    )
+
+    config_manager = ModuleType("custom_components.rinnai.core.config_manager")
+    config_manager.config_manager = MagicMock()
+    monkeypatch.setitem(
+        sys.modules, "custom_components.rinnai.core.config_manager", config_manager
+    )
+
+    sys.modules.pop("custom_components.rinnai.core.client", None)
+    module = importlib.import_module("custom_components.rinnai.core.client")
+    return module
+
+
+@pytest.mark.asyncio
+async def test_login_uses_app_user_agent_and_version(client_module):
+    """The login request must look like the current mobile app."""
+    session = MagicMock()
+    response = MagicMock()
+    response.json = AsyncMock(return_value={"success": True, "data": {"token": "token"}})
+    session.get = AsyncMock(return_value=response)
+    client_module.async_get_clientsession = MagicMock(return_value=session)
+
+    client = client_module.RinnaiClient(MagicMock(), "user", "password")
+
+    assert await client.login() is True
+    request = session.get.await_args
+    assert request.kwargs["headers"] == {
+        "User-Agent": client_module.API_HEADERS["User-Agent"]
+    }
+    assert request.kwargs["params"]["appVersion"] == client_module.APP_VERSION
+
+
+def test_authenticated_headers_include_user_agent(client_module):
+    """Authenticated API requests must retain the mobile app User-Agent."""
+    client_module.async_get_clientsession = MagicMock(return_value=MagicMock())
+    client = client_module.RinnaiClient(MagicMock(), "user", "password")
+    client._token = "token"
+
+    assert client._http_headers(authenticated=True) == {
+        "User-Agent": client_module.API_HEADERS["User-Agent"],
+        "Authorization": "Basic token",
+    }


### PR DESCRIPTION
## Summary

- identify HTTP requests as Rinnai Smart Home app 3.10.0 using the captured mobile User-Agent
- apply the same request headers to login, device discovery/state, and configurable authenticated API calls
- avoid logging the credential-bearing login URL when a non-JSON response is returned
- add regression coverage for login metadata and authenticated request headers

## Root cause

The Rinnai API gateway now rejects aiohttp's default User-Agent. Rejected requests still return HTTP 200, but the body is HTML instead of JSON, causing `response.json()` to raise `ContentTypeError`.

A controlled live check confirmed that changing only the User-Agent changes the response from `200 text/html` to `200 application/json` with `success=true`. The same behavior also applies to authenticated device-list requests, so the header must be used globally rather than only during login.

## Impact

Home Assistant can authenticate and continue using the HTTP API again. If the gateway returns HTML in the future, the login error no longer includes the full URL containing password-equivalent query parameters.

## Validation

- `uv run pytest` — 327 passed
- `python -m compileall -q custom_components/rinnai tests`
- live differential validation against login and device-list endpoints (no credentials included in this PR)