### PR TITLE
feat: add Q85 support and prepare v1.0.6

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
         body: |
           release： ${{ steps.tag.outputs.TAG_NAME }}
         draft: false
-        prerelease: false
+        prerelease: ${{ contains(steps.tag.outputs.TAG_NAME, '-beta') }}
         files: ${{ steps.tag.outputs.TAG_NAME }}.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/custom_components/rinnai/__init__.py
+++ b/custom_components/rinnai/__init__.py
@@ -21,6 +21,7 @@ from .const import (
 )
 
 PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.NUMBER,
     Platform.SENSOR,

--- a/custom_components/rinnai/button.py
+++ b/custom_components/rinnai/button.py
@@ -1,0 +1,59 @@
+"""Support for stateless Rinnai device commands."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import RinnaiCoordinator
+from .entity import RinnaiEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up configured Rinnai buttons."""
+    coordinator: RinnaiCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[RinnaiCommandButton] = []
+
+    for device_id in coordinator.data["devices"]:
+        device = coordinator.get_device(device_id)
+        if not device or not device.config:
+            continue
+        for config in device.config.entities.get("button", []):
+            if config.get("type") == "command_button":
+                entities.append(RinnaiCommandButton(coordinator, device_id, config))
+
+    _LOGGER.debug("Setting up %d button entities", len(entities))
+    async_add_entities(entities)
+
+
+class RinnaiCommandButton(RinnaiEntity, ButtonEntity):
+    """A button for a device command whose protocol semantics are toggle-only."""
+
+    def __init__(
+        self,
+        coordinator: RinnaiCoordinator,
+        device_id: str,
+        config: dict[str, Any],
+    ) -> None:
+        super().__init__(coordinator, device_id, config)
+        self._command_key = config["command_key"]
+        self._command_value = config["command_value"]
+
+    async def async_press(self) -> None:
+        """Send one stateless command and leave state reporting to sensors."""
+        if not await self.coordinator.async_send_command(
+            self._device_id,
+            {self._command_key: self._command_value},
+        ):
+            _LOGGER.error("Failed to send button command: %s", self._command_key)

--- a/custom_components/rinnai/climate.py
+++ b/custom_components/rinnai/climate.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import RinnaiCoordinator
 from .entity import RinnaiEntity
-from .core.entity_utils import execute_transition
+from .core.entity_utils import execute_transition, resolve_mode_code
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,6 +67,7 @@ class RinnaiHeatingClimateEntity(RinnaiEntity, ClimateEntity):
         self._mode_codes = config["mode_codes"]
         self._temp_settings = config["temp_settings"]
         self._active_states = config["active_states"]
+        self._mode_match = config.get("mode_match", "exact")
         
         # Defaults config
         defaults = config.get("defaults", {})
@@ -95,9 +96,8 @@ class RinnaiHeatingClimateEntity(RinnaiEntity, ClimateEntity):
 
     def _get_mode_from_code(self, code: str) -> str:
         """Resolve mode key from operation mode code."""
-        for mode_key, codes in self._mode_codes.items():
-            if code in codes:
-                return mode_key
+        if mode_key := resolve_mode_code(code, self._mode_codes, self._mode_match):
+            return mode_key
         _LOGGER.debug(
             "Device %s: unknown operation mode code '%s', defaulting to '%s'",
             self._device_id, code, self._off_mode,

--- a/custom_components/rinnai/core/client.py
+++ b/custom_components/rinnai/core/client.py
@@ -24,6 +24,7 @@ from ..const import (
     REFESH_TIME,
 )
 from .config_manager import config_manager
+from .entity_utils import normalize_dynamic_mqtt_code
 from .mqtt_client import RinnaiMQTTClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -417,16 +418,36 @@ class RinnaiClient:
                 try:
                     payload = json.loads(msg.payload)
 
-                    if topic_type == "inf":
+                    if topic_type == "inf" and payload.get("enl"):
                         code = payload.get("code")
-                        if payload.get("enl") and code == proto["info_code"]:
-                            state_data = self._process_device_info(payload)
-                            if state_data:
-                                self._handle_state_update(device_id, state_data)
-                        elif payload.get("enl") and code == proto["reservation_code"]:
+                        if code == proto["reservation_code"]:
                             state_data = self._process_reservation_info(payload)
-                            if state_data:
-                                self._handle_state_update(device_id, state_data)
+                        elif code == proto["info_code"]:
+                            state_data = self._process_device_info(payload)
+                        else:
+                            config = self._device_configs.get(device_id)
+                            dynamic_code = None
+                            if config and config.features.get("dynamic_mqtt_code"):
+                                dynamic_code = normalize_dynamic_mqtt_code(
+                                    code,
+                                    {
+                                        "0",
+                                        proto["info_code"],
+                                        proto["reservation_code"],
+                                    },
+                                )
+                            if dynamic_code:
+                                candidate_state = self._process_device_info(payload)
+                                known_fields = set(config.state_mapping.values())
+                                if known_fields.intersection(candidate_state):
+                                    self.devices[device_id]["authCode"] = dynamic_code
+                                    state_data = candidate_state
+                                else:
+                                    state_data = {}
+                            else:
+                                state_data = {}
+                        if state_data:
+                            self._handle_state_update(device_id, state_data)
                     elif topic_type == "stg":
                         if payload.get("egy") and payload.get("ptn") == proto["energy_pattern"]:
                             state_data = self._process_energy_data(payload, device_id)

--- a/custom_components/rinnai/core/client.py
+++ b/custom_components/rinnai/core/client.py
@@ -427,7 +427,7 @@ class RinnaiClient:
                         else:
                             config = self._device_configs.get(device_id)
                             dynamic_code = None
-                            if config and config.features.get("dynamic_mqtt_code"):
+                            if config:
                                 dynamic_code = normalize_dynamic_mqtt_code(
                                     code,
                                     {

--- a/custom_components/rinnai/core/client.py
+++ b/custom_components/rinnai/core/client.py
@@ -24,7 +24,10 @@ from ..const import (
     REFESH_TIME,
 )
 from .config_manager import config_manager
-from .entity_utils import normalize_dynamic_mqtt_code
+from .entity_utils import (
+    is_dynamic_mqtt_code_enabled,
+    normalize_dynamic_mqtt_code,
+)
 from .mqtt_client import RinnaiMQTTClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -427,7 +430,7 @@ class RinnaiClient:
                         else:
                             config = self._device_configs.get(device_id)
                             dynamic_code = None
-                            if config:
+                            if is_dynamic_mqtt_code_enabled(config):
                                 dynamic_code = normalize_dynamic_mqtt_code(
                                     code,
                                     {

--- a/custom_components/rinnai/core/entity_utils.py
+++ b/custom_components/rinnai/core/entity_utils.py
@@ -10,6 +10,52 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def resolve_mode_code(
+    code: Any,
+    mode_codes: dict[str, list[str]],
+    match: str = "exact",
+) -> str | None:
+    """Resolve a raw operation-mode value without changing legacy matching."""
+    normalized = str(code).upper()
+    for mode_key, configured_codes in mode_codes.items():
+        candidates = [str(item).upper() for item in configured_codes]
+        if match == "prefix":
+            if any(candidate and normalized.startswith(candidate) for candidate in candidates):
+                return mode_key
+        elif normalized in candidates:
+            return mode_key
+    return None
+
+
+def get_hex_byte(value: Any, byte_index: int) -> str | None:
+    """Return one byte from an even-length hexadecimal state value."""
+    if byte_index < 0:
+        return None
+    normalized = str(value).strip().upper()
+    if normalized.startswith("0X"):
+        normalized = normalized[2:]
+    if len(normalized) % 2 or any(char not in "0123456789ABCDEF" for char in normalized):
+        return None
+    start = byte_index * 2
+    if len(normalized) < start + 2:
+        return None
+    return normalized[start : start + 2]
+
+
+def normalize_dynamic_mqtt_code(
+    code: Any,
+    reserved_codes: set[str],
+) -> str | None:
+    """Validate an opt-in device command code learned from an info message."""
+    normalized = str(code).strip().upper()
+    reserved = {str(item).strip().upper() for item in reserved_codes}
+    if normalized in reserved:
+        return None
+    if len(normalized) != 4 or any(char not in "0123456789ABCDEF" for char in normalized):
+        return None
+    return normalized
+
 def get_state_value(device_state: Any, attribute_key: str, mapping: dict[str, str] | None = None) -> Any:
     """
     Get value from device state using mapping.

--- a/custom_components/rinnai/core/entity_utils.py
+++ b/custom_components/rinnai/core/entity_utils.py
@@ -56,6 +56,15 @@ def normalize_dynamic_mqtt_code(
         return None
     return normalized
 
+
+def is_dynamic_mqtt_code_enabled(config: Any) -> bool:
+    """Return whether a device explicitly opts in to dynamic MQTT codes."""
+    if config is None:
+        return False
+    features = getattr(config, "features", {})
+    return bool(features.get("dynamic_mqtt_code", False))
+
+
 def get_state_value(device_state: Any, attribute_key: str, mapping: dict[str, str] | None = None) -> Any:
     """
     Get value from device state using mapping.

--- a/custom_components/rinnai/core/entity_utils.py
+++ b/custom_components/rinnai/core/entity_utils.py
@@ -47,7 +47,7 @@ def normalize_dynamic_mqtt_code(
     code: Any,
     reserved_codes: set[str],
 ) -> str | None:
-    """Validate an opt-in device command code learned from an info message."""
+    """Validate a device command code learned from an info message."""
     normalized = str(code).strip().upper()
     reserved = {str(item).strip().upper() for item in reserved_codes}
     if normalized in reserved:

--- a/custom_components/rinnai/devices/0F060001.json
+++ b/custom_components/rinnai/devices/0F060001.json
@@ -2,6 +2,7 @@
     "name": "Rinnai Boiler Q85",
     "features": {
         "heat_type": "Q85_HEAT_OVEN",
+        "dynamic_mqtt_code": true,
         "gas_consumption_digits": 8,
         "energy_data_keys": [
             "gasUsed",

--- a/custom_components/rinnai/devices/0F060001.json
+++ b/custom_components/rinnai/devices/0F060001.json
@@ -16,8 +16,7 @@
             "1": "0101DB446CDB006E4818C680017F80017F",
             "2": "0102DB446CDB006E4818C680017F80017F",
             "3": "0103DB446CDB006E4818C680017F80017F"
-        },
-        "dynamic_mqtt_code": true
+        }
     },
     "schedule_config": {
         "total_length": 34,

--- a/custom_components/rinnai/devices/0F060001.json
+++ b/custom_components/rinnai/devices/0F060001.json
@@ -1,0 +1,410 @@
+{
+    "name": "Rinnai Boiler Q85",
+    "features": {
+        "heat_type": "Q85_HEAT_OVEN",
+        "gas_consumption_digits": 8,
+        "energy_data_keys": [
+            "gasUsed",
+            "supplyTime",
+            "totalPowerSupplyTime",
+            "totalHeatingBurningTime",
+            "totalHotWaterBurningTime",
+            "heatingBurningTimes",
+            "hotWaterBurningTimes"
+        ],
+        "reservation_mode_presets": {
+            "1": "0101DB446CDB006E4818C680017F80017F",
+            "2": "0102DB446CDB006E4818C680017F80017F",
+            "3": "0103DB446CDB006E4818C680017F80017F"
+        },
+        "dynamic_mqtt_code": true
+    },
+    "schedule_config": {
+        "total_length": 34,
+        "status_byte_index": 0,
+        "mode_byte_index": 1,
+        "data_start_byte_index": 2,
+        "bytes_per_mode": 3,
+        "mode_count": 5
+    },
+    "supported_requests": [
+        "get_schedule",
+        "save_schedule"
+    ],
+    "processors": {
+        "hotWaterTempSetting": [
+            "hex_to_int"
+        ],
+        "heatingTempSetting": [
+            "hex_to_int"
+        ],
+        "waterPressure": [
+            "hex_to_int",
+            {
+                "func": "divide",
+                "args": [
+                    1000
+                ]
+            }
+        ],
+        "actualUseTime": [
+            "hex_to_int"
+        ],
+        "totalPowerSupplyTime": [
+            "hex_to_int"
+        ],
+        "totalHeatingBurningTime": [
+            "hex_to_int"
+        ],
+        "totalHotWaterBurningTime": [
+            "hex_to_int"
+        ],
+        "heatingBurningTimes": [
+            "hex_to_int"
+        ],
+        "hotWaterBurningTimes": [
+            "hex_to_int"
+        ],
+        "gasConsumption": [
+            "hex_to_int",
+            {
+                "func": "divide",
+                "args": [
+                    10000
+                ]
+            }
+        ],
+        "burningStateDHW": [],
+        "burningStateCH": []
+    },
+    "state_mapping": {
+        "hot_water_temp": "hotWaterTempSetting",
+        "heating_temp": "heatingTempSetting",
+        "operation_mode": "operationMode",
+        "burning_state_dhw": "burningStateDHW",
+        "burning_state_ch": "burningStateCH",
+        "water_pressure": "waterPressure",
+        "gas_usage": "gasConsumption",
+        "supply_time": "actualUseTime",
+        "total_power_supply_time": "totalPowerSupplyTime",
+        "total_heating_burning_time": "totalHeatingBurningTime",
+        "total_hot_water_burning_time": "totalHotWaterBurningTime",
+        "heating_burning_times": "heatingBurningTimes",
+        "hot_water_burning_times": "hotWaterBurningTimes",
+        "reservation_mode": "heatingReservationMode",
+        "byte_str": "byteStr"
+    },
+    "entities": {
+        "water_heater": [
+            {
+                "name": "热水器",
+                "key": "main",
+                "min_temp": 35,
+                "max_temp": 60,
+                "step": 1,
+                "command_topic": "hotWaterTempSetting",
+                "state_attribute": "hot_water_temp",
+                "operation_mode": "Hot Water"
+            }
+        ],
+        "climate": [
+            {
+                "name": "采暖",
+                "key": "main",
+                "min_temp": 40,
+                "max_temp": 80,
+                "step": 1,
+                "defaults": {
+                    "off_mode": "standby",
+                    "on_mode": "normal",
+                    "action_attribute": "burning_state_ch"
+                },
+                "mode_match": "prefix",
+                "modes": {
+                    "standby": {
+                        "label": "Heating Off",
+                        "value": "standby"
+                    },
+                    "normal": {
+                        "label": "Normal Heating",
+                        "value": "normal"
+                    },
+                    "energy_saving": {
+                        "label": "Heating Energy Saving",
+                        "value": "energy_saving"
+                    },
+                    "outdoor": {
+                        "label": "Heating Outdoor",
+                        "value": "outdoor"
+                    }
+                },
+                "transitions": {
+                    "standby_to_normal": [
+                        {
+                            "cmd": "heatingSwitch",
+                            "value": "31"
+                        }
+                    ],
+                    "standby_to_energy_saving": [
+                        {
+                            "cmd": "heatingSwitch",
+                            "value": "31",
+                            "delay": 2
+                        },
+                        {
+                            "cmd": "ecoMode",
+                            "value": "31"
+                        }
+                    ],
+                    "standby_to_outdoor": [
+                        {
+                            "cmd": "heatingSwitch",
+                            "value": "31",
+                            "delay": 2
+                        },
+                        {
+                            "cmd": "outdoorMode",
+                            "value": "31"
+                        }
+                    ],
+                    "normal_to_standby": [
+                        {
+                            "cmd": "heatingSwitch",
+                            "value": "31"
+                        }
+                    ],
+                    "normal_to_energy_saving": [
+                        {
+                            "cmd": "ecoMode",
+                            "value": "31"
+                        }
+                    ],
+                    "normal_to_outdoor": [
+                        {
+                            "cmd": "outdoorMode",
+                            "value": "31"
+                        }
+                    ],
+                    "energy_saving_to_standby": [
+                        {
+                            "cmd": "heatingSwitch",
+                            "value": "31"
+                        }
+                    ],
+                    "energy_saving_to_normal": [
+                        {
+                            "cmd": "ecoMode",
+                            "value": "31"
+                        }
+                    ],
+                    "energy_saving_to_outdoor": [
+                        {
+                            "cmd": "ecoMode",
+                            "value": "31",
+                            "delay": 2
+                        },
+                        {
+                            "cmd": "outdoorMode",
+                            "value": "31"
+                        }
+                    ],
+                    "outdoor_to_standby": [
+                        {
+                            "cmd": "heatingSwitch",
+                            "value": "31"
+                        }
+                    ],
+                    "outdoor_to_normal": [
+                        {
+                            "cmd": "outdoorMode",
+                            "value": "31"
+                        }
+                    ],
+                    "outdoor_to_energy_saving": [
+                        {
+                            "cmd": "outdoorMode",
+                            "value": "31",
+                            "delay": 2
+                        },
+                        {
+                            "cmd": "ecoMode",
+                            "value": "31"
+                        }
+                    ]
+                },
+                "mode_codes": {
+                    "standby": [
+                        "02",
+                        "12"
+                    ],
+                    "normal": [
+                        "03"
+                    ],
+                    "energy_saving": [
+                        "43"
+                    ],
+                    "outdoor": [
+                        "83"
+                    ]
+                },
+                "temp_settings": {
+                    "normal": {
+                        "read": "heating_temp",
+                        "write": "heatingTempSetting"
+                    },
+                    "energy_saving": {
+                        "read": "heating_temp",
+                        "write": "heatingTempSetting"
+                    },
+                    "outdoor": {
+                        "fixed": 40
+                    }
+                },
+                "active_states": [
+                    "31",
+                    "32"
+                ]
+            }
+        ],
+        "sensor": [
+            {
+                "key": "hot_water_temp",
+                "name": "生活热水设定温度",
+                "device_class": "temperature",
+                "state_class": "measurement",
+                "unit_of_measurement": "°C",
+                "state_attribute": "hot_water_temp"
+            },
+            {
+                "key": "heating_temp",
+                "name": "采暖设定温度",
+                "device_class": "temperature",
+                "state_class": "measurement",
+                "unit_of_measurement": "°C",
+                "state_attribute": "heating_temp"
+            },
+            {
+                "key": "burning_state_dhw",
+                "name": "热水燃烧状态",
+                "entity_category": "diagnostic",
+                "state_attribute": "burning_state_dhw",
+                "value_map": {
+                    "30": "Standby",
+                    "31": "Burning",
+                    "32": "Burning",
+                    "33": "Error"
+                }
+            },
+            {
+                "key": "burning_state_ch",
+                "name": "采暖燃烧状态",
+                "entity_category": "diagnostic",
+                "state_attribute": "burning_state_ch",
+                "value_map": {
+                    "30": "Standby",
+                    "31": "Burning",
+                    "32": "Burning",
+                    "33": "Error"
+                }
+            },
+            {
+                "key": "water_pressure",
+                "name": "水压",
+                "device_class": "pressure",
+                "state_class": "measurement",
+                "unit_of_measurement": "bar",
+                "state_attribute": "water_pressure"
+            },
+            {
+                "key": "gas_usage",
+                "name": "当前燃气用量",
+                "device_class": "gas",
+                "state_class": "total_increasing",
+                "unit_of_measurement": "m³",
+                "entity_category": "diagnostic",
+                "state_attribute": "gas_usage"
+            },
+            {
+                "key": "total_heating_burning_time",
+                "name": "采暖累计燃烧时间",
+                "device_class": "duration",
+                "state_class": "total_increasing",
+                "unit_of_measurement": "h",
+                "entity_category": "diagnostic",
+                "state_attribute": "total_heating_burning_time"
+            },
+            {
+                "key": "total_hot_water_burning_time",
+                "name": "热水累计燃烧时间",
+                "device_class": "duration",
+                "state_class": "total_increasing",
+                "unit_of_measurement": "h",
+                "entity_category": "diagnostic",
+                "state_attribute": "total_hot_water_burning_time"
+            },
+            {
+                "key": "heating_reservation",
+                "name": "采暖预约状态",
+                "type": "reservation_sensor",
+                "state_attribute": "byte_str"
+            },
+            {
+                "key": "circulation_status",
+                "name": "一键循环状态",
+                "entity_category": "diagnostic",
+                "state_attribute": "operation_mode",
+                "type": "circulation_sensor",
+                "byte_index": 2,
+                "on_value": "0C"
+            }
+        ],
+        "switch": [
+            {
+                "key": "heating_reservation",
+                "name": "采暖预约开关",
+                "type": "reservation_switch",
+                "state_attribute": "byte_str"
+            }
+        ],
+        "select": [
+            {
+                "key": "reservation_mode",
+                "name": "预约模式选择",
+                "options": [
+                    "Mode 1",
+                    "Mode 2",
+                    "Mode 3",
+                    "Mode 4",
+                    "Mode 5"
+                ],
+                "command_type": "schedule_mode",
+                "state_attribute": "byte_str"
+            }
+        ],
+        "text": [
+            {
+                "key": "schedule_mode_4",
+                "name": "自定义1 设置",
+                "mode_index": 4,
+                "command_type": "schedule_data",
+                "state_attribute": "byte_str"
+            },
+            {
+                "key": "schedule_mode_5",
+                "name": "自定义2 设置",
+                "mode_index": 5,
+                "command_type": "schedule_data",
+                "state_attribute": "byte_str"
+            }
+        ],
+        "button": [
+            {
+                "key": "water_circulation",
+                "name": "一键循环",
+                "type": "command_button",
+                "command_key": "temporaryCycleInsulationSetting",
+                "command_value": "31"
+            }
+        ]
+    }
+}

--- a/custom_components/rinnai/manifest.json
+++ b/custom_components/rinnai/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "paho-mqtt>=1.6.1"
   ],
-  "version": "v1.0.4"
+  "version": "v1.0.6-q85-beta.1"
 }

--- a/custom_components/rinnai/sensor.py
+++ b/custom_components/rinnai/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import CONF_EXPERIMENTAL_SENSORS, DOMAIN
 from .coordinator import RinnaiCoordinator
+from .core.entity_utils import get_hex_byte
 from .entity import RinnaiEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,6 +46,8 @@ async def async_setup_entry(
                 sensor_type = config.get("type", "generic")
                 if sensor_type == "reservation_sensor":
                     entities.append(RinnaiHeatingReservationSensor(coordinator, device_id, config))
+                elif sensor_type == "circulation_sensor":
+                    entities.append(RinnaiCirculationSensor(coordinator, device_id, config))
                 else:
                     entities.append(RinnaiGenericSensor(coordinator, device_id, config, experimental_enabled))
 
@@ -216,3 +219,39 @@ class RinnaiHeatingReservationSensor(RinnaiEntity, SensorEntity):
                     attrs["current_schedule"] = schedule_str
         
         self._attr_extra_state_attributes = attrs
+
+
+class RinnaiCirculationSensor(RinnaiEntity, SensorEntity):
+    """Expose a circulation state encoded in one operation-mode byte."""
+
+    def __init__(
+        self,
+        coordinator: RinnaiCoordinator,
+        device_id: str,
+        config: dict[str, Any],
+    ) -> None:
+        super().__init__(coordinator, device_id, config)
+        self._attr_device_class = SensorDeviceClass.ENUM
+        self._attr_options = ["Active", "Inactive", "Unknown"]
+        self._state_attribute = config["state_attribute"]
+        self._byte_index = int(config.get("byte_index", 2))
+        self._on_value = str(config.get("on_value", "0C")).upper()
+        self._update_attributes()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._update_attributes()
+        self.async_write_ha_state()
+
+    def _update_attributes(self) -> None:
+        raw_value = self.get_state_value(self._state_attribute)
+        byte_value = get_hex_byte(raw_value, self._byte_index)
+        if byte_value is None:
+            self._attr_native_value = "Unknown"
+        else:
+            self._attr_native_value = (
+                "Active" if byte_value == self._on_value else "Inactive"
+            )
+        self._attr_extra_state_attributes = {
+            "raw_operation_mode": raw_value,
+        }

--- a/custom_components/rinnai/translations/en.json
+++ b/custom_components/rinnai/translations/en.json
@@ -22,6 +22,20 @@
             "burning_state": {
                 "name": "Burning State"
             },
+            "burning_state_dhw": {
+                "name": "DHW Burning State"
+            },
+            "burning_state_ch": {
+                "name": "CH Burning State"
+            },
+            "circulation_status": {
+                "name": "One-key Circulation Status",
+                "state": {
+                    "Active": "Active",
+                    "Inactive": "Inactive",
+                    "Unknown": "Unknown"
+                }
+            },
             "gas_usage": {
                 "name": "Gas Usage"
             },
@@ -57,6 +71,11 @@
             },
             "heating_reservation": {
                 "name": "Heating Reservation Status"
+            }
+        },
+        "button": {
+            "water_circulation": {
+                "name": "One-key Circulation"
             }
         },
         "climate": {

--- a/custom_components/rinnai/translations/zh-Hans.json
+++ b/custom_components/rinnai/translations/zh-Hans.json
@@ -28,6 +28,30 @@
                     "Error": "错误"
                 }
             },
+            "burning_state_dhw": {
+                "name": "热水燃烧状态",
+                "state": {
+                    "Standby": "待机",
+                    "Burning": "燃烧中",
+                    "Error": "错误"
+                }
+            },
+            "burning_state_ch": {
+                "name": "采暖燃烧状态",
+                "state": {
+                    "Standby": "待机",
+                    "Burning": "燃烧中",
+                    "Error": "错误"
+                }
+            },
+            "circulation_status": {
+                "name": "一键循环状态",
+                "state": {
+                    "Active": "运行中",
+                    "Inactive": "未运行",
+                    "Unknown": "未知"
+                }
+            },
             "gas_usage": {
                 "name": "当前燃气用量"
             },
@@ -63,6 +87,11 @@
             },
             "heating_reservation": {
                 "name": "采暖预约状态"
+            }
+        },
+        "button": {
+            "water_circulation": {
+                "name": "一键循环"
             }
         },
         "climate": {

--- a/tests/test_q85.py
+++ b/tests/test_q85.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 
 CORE_DIR = Path(__file__).parents[1] / "custom_components" / "rinnai" / "core"
 sys.path.insert(0, str(CORE_DIR))
 
 from entity_utils import (  # noqa: E402
     get_hex_byte,
+    is_dynamic_mqtt_code_enabled,
     normalize_dynamic_mqtt_code,
     resolve_mode_code,
 )
@@ -103,6 +105,24 @@ def test_dynamic_mqtt_code_rejects_protocol_message_codes() -> None:
     assert normalize_dynamic_mqtt_code("03F1", reserved) is None
     assert normalize_dynamic_mqtt_code("123", reserved) is None
     assert normalize_dynamic_mqtt_code("ZZZZ", reserved) is None
+
+
+def test_dynamic_mqtt_code_is_only_enabled_for_q85() -> None:
+    device_configs = CONFIG_PATH.parent.glob("*.json")
+    enabled_configs = [
+        path.name
+        for path in device_configs
+        if json.loads(path.read_text(encoding="utf-8"))
+        .get("features", {})
+        .get("dynamic_mqtt_code", False)
+    ]
+
+    assert enabled_configs == ["0F060001.json"]
+    assert is_dynamic_mqtt_code_enabled(
+        SimpleNamespace(features={"dynamic_mqtt_code": True})
+    )
+    assert not is_dynamic_mqtt_code_enabled(SimpleNamespace(features={}))
+    assert not is_dynamic_mqtt_code_enabled(None)
 
 
 def test_q85_schedule_shape_is_explicit() -> None:

--- a/tests/test_q85.py
+++ b/tests/test_q85.py
@@ -109,7 +109,6 @@ def test_q85_schedule_shape_is_explicit() -> None:
     config = load_q85()
 
     assert config["features"]["heat_type"] == "Q85_HEAT_OVEN"
-    assert config["features"]["dynamic_mqtt_code"] is True
     assert config["schedule_config"] == {
         "total_length": 34,
         "status_byte_index": 0,

--- a/tests/test_q85.py
+++ b/tests/test_q85.py
@@ -1,0 +1,120 @@
+"""Regression tests for the isolated Q85 device support."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+CORE_DIR = Path(__file__).parents[1] / "custom_components" / "rinnai" / "core"
+sys.path.insert(0, str(CORE_DIR))
+
+from entity_utils import (  # noqa: E402
+    get_hex_byte,
+    normalize_dynamic_mqtt_code,
+    resolve_mode_code,
+)
+
+CONFIG_PATH = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "rinnai"
+    / "devices"
+    / "0F060001.json"
+)
+
+
+def load_q85() -> dict:
+    """Load the Q85 JSON as the integration does."""
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def test_q85_temperature_encoding_and_ranges() -> None:
+    config = load_q85()
+    water_heater = config["entities"]["water_heater"][0]
+    climate = config["entities"]["climate"][0]
+
+    assert config["processors"]["hotWaterTempSetting"] == ["hex_to_int"]
+    assert water_heater["command_topic"] == "hotWaterTempSetting"
+    assert (water_heater["min_temp"], water_heater["max_temp"]) == (35, 60)
+    assert (climate["min_temp"], climate["max_temp"]) == (40, 80)
+
+
+def test_q85_operation_mode_prefixes() -> None:
+    climate = load_q85()["entities"]["climate"][0]
+    mode_codes = climate["mode_codes"]
+
+    assert climate["mode_match"] == "prefix"
+    assert resolve_mode_code("020000", mode_codes, "prefix") == "standby"
+    assert resolve_mode_code("12000C", mode_codes, "prefix") == "standby"
+    assert resolve_mode_code("03000C", mode_codes, "prefix") == "normal"
+    assert resolve_mode_code("430000", mode_codes, "prefix") == "energy_saving"
+    assert resolve_mode_code("830000", mode_codes, "prefix") == "outdoor"
+    assert resolve_mode_code("FF0000", mode_codes, "prefix") is None
+
+
+def test_q85_has_every_mode_transition() -> None:
+    climate = load_q85()["entities"]["climate"][0]
+    modes = set(climate["modes"])
+    expected = {
+        f"{source}_to_{target}"
+        for source in modes
+        for target in modes
+        if source != target
+    }
+
+    assert set(climate["transitions"]) == expected
+    assert all(
+        step["value"] == "31"
+        for steps in climate["transitions"].values()
+        for step in steps
+    )
+
+
+def test_q85_circulation_is_stateless_button() -> None:
+    config = load_q85()
+    buttons = config["entities"]["button"]
+    switches = config["entities"]["switch"]
+    status = next(
+        sensor
+        for sensor in config["entities"]["sensor"]
+        if sensor["key"] == "circulation_status"
+    )
+
+    assert not any(switch["key"] == "water_circulation" for switch in switches)
+    assert buttons == [
+        {
+            "key": "water_circulation",
+            "name": "一键循环",
+            "type": "command_button",
+            "command_key": "temporaryCycleInsulationSetting",
+            "command_value": "31",
+        }
+    ]
+    assert get_hex_byte("03000C", status["byte_index"]) == status["on_value"]
+    assert get_hex_byte("030000", status["byte_index"]) == "00"
+    assert get_hex_byte("invalid", status["byte_index"]) is None
+
+
+def test_dynamic_mqtt_code_rejects_protocol_message_codes() -> None:
+    reserved = {"0", "FFFF", "03F1"}
+
+    assert normalize_dynamic_mqtt_code("1a2b", reserved) == "1A2B"
+    assert normalize_dynamic_mqtt_code("FFFF", reserved) is None
+    assert normalize_dynamic_mqtt_code("03F1", reserved) is None
+    assert normalize_dynamic_mqtt_code("123", reserved) is None
+    assert normalize_dynamic_mqtt_code("ZZZZ", reserved) is None
+
+
+def test_q85_schedule_shape_is_explicit() -> None:
+    config = load_q85()
+
+    assert config["features"]["heat_type"] == "Q85_HEAT_OVEN"
+    assert config["features"]["dynamic_mqtt_code"] is True
+    assert config["schedule_config"] == {
+        "total_length": 34,
+        "status_byte_index": 0,
+        "mode_byte_index": 1,
+        "data_start_byte_index": 2,
+        "bytes_per_mode": 3,
+        "mode_count": 5,
+    }


### PR DESCRIPTION
## Summary

- add isolated Q85 boiler configuration and entities
- enable dynamic MQTT code handling only for Q85 through an explicit device feature
- preserve existing G56, E32, E51 and other device configurations
- sync the branch with the latest `master`, including PR #16
- update the integration version to `v1.0.6`
- correct the E51 gas-entity regression test after PR #16 intentionally removed that entity

## Validation

- full test suite: **389 passed**
- Python compilation passed
- JSON validation and `git diff --check` passed
- Q85 beta package `v1.0.6-q85-beta.1` verified on device
